### PR TITLE
upgrade ferryman and ferryman-extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "npm": ">= 4.0.0"
   },
   "dependencies": {
-    "@blendededge/ferryman-extensions": "^1.1.2",
-    "@openintegrationhub/ferryman": "~2.1.0",
+    "@blendededge/ferryman-extensions": "^1.2.1",
+    "@openintegrationhub/ferryman": "^2.1.1",
     "object-sizeof": "^1.6.1",
     "uuid": "^8.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,12 +279,13 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@blendededge/ferryman-extensions@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@blendededge/ferryman-extensions/-/ferryman-extensions-1.1.2.tgz"
-  integrity sha512-ZU7ZXTlJWIQQOEjvsEj/QY7VKk2GykVMTa1+BRqyAjB4LblFxDBQx8ZVqH1aSXKKJhxo8ZG3xEA0l0cb81bYhA==
+"@blendededge/ferryman-extensions@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@blendededge/ferryman-extensions/-/ferryman-extensions-1.2.1.tgz#6c5ab22d2ca856c74e7cd30caed5f3931e6b54d9"
+  integrity sha512-+BhCLacjXzht0bkFODoLqqdn2VzxPc2vjRJ+tSl7tALFxB+wN7L1UQPvqNWCcvxQochrQDhsjGEhLOloXWLK+Q==
   dependencies:
     axios "^0.27.0"
+    events "^3.3.0"
     lodash "^4.17.21"
     uuid "^8.3.2"
 
@@ -535,10 +536,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openintegrationhub/ferryman@~2.1.0":
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/@openintegrationhub/ferryman/-/ferryman-2.1.0.tgz"
-  integrity sha512-fjLjHaUgDnNxraRDa07G8Jj96wOIHWRneGcFZqF9WfrzN30yckOBfYTdJ1HUauf0sKDi+bp+Dtl/G7Bfg8uGoQ==
+"@openintegrationhub/ferryman@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@openintegrationhub/ferryman/-/ferryman-2.1.1.tgz#9c741a0a2f3ac569ccb71d92838221ea5a624576"
+  integrity sha512-/wMCuOLczuE/iHkxk348KH5n2Fl5ewqXuEbD7GSU98Ukv5rjzcOVbaZUQDczTNuXfwxaxkca8Hh5Rw4MDB4Vcg==
   dependencies:
     amqplib "0.8.0"
     bunyan "1.8.10"
@@ -2114,6 +2115,11 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 exec-sh@^0.3.2:
   version "0.3.6"


### PR DESCRIPTION
- upgrades `@openintegrationhub/ferryman` to `^2.1.1`
- upgrades `@blendededge/ferryman-extensions` to `^1.2.1`